### PR TITLE
Puma reports metrics less often and reasonable

### DIFF
--- a/puma.rb
+++ b/puma.rb
@@ -25,12 +25,12 @@ describe_samples do
   max_capacity = parsed.map(&:last).map(&:to_i).sum
 
   names_and_values = []
-  names_and_values << ["Puma Free Capacity", free_capacity]
-  names_and_values << ["Puma Max Capacity", max_capacity]
-  names_and_values << ["Puma Used Capacity", max_capacity - free_capacity]
+  names_and_values << ["Puma Free Capacity", free_capacity, "Count"]
+  names_and_values << ["Puma Max Capacity", max_capacity, "Count"]
+  names_and_values << ["Puma Used Capacity", max_capacity - free_capacity, "Count"]
   if max_capacity.positive?
-    relative_capacity = free_capacity / max_capacity.to_f
-    names_and_values << ["Puma Free Relative Capacity", relative_capacity]
+    relative_capacity = 100.0 * free_capacity / max_capacity.to_f
+    names_and_values << ["Puma Free Relative Capacity", relative_capacity, "Percent"]
   end
 
   aggregation_dimensions = {}
@@ -38,13 +38,13 @@ describe_samples do
     aggregation_dimensions[:group] = aggregation_group
   end
 
-  names_and_values.each do |(name, value)|
+  names_and_values.each do |(name, value, unit)|
     sample(
       aggregate: aggregation_dimensions,
       dimensions: {ClusterName: ec2.ecs_cluster},
       name: name,
-      storage_resolution: 1,
-      unit: "Count",
+      storage_resolution: 60,
+      unit: unit,
       value: value
     )
   end


### PR DESCRIPTION
- `storage_resolution` is changed from 1 (highest) to 60 (regular: 1 minute). To keep only one sample is sufficient.
- `unit` is not always "Count", but the average is "Percent". Also changed the related value - hoping that AWS considers 100% be reported as a `100`.