### PR TITLE
socket: read data from existing stats file

### DIFF
--- a/socket.rb
+++ b/socket.rb
@@ -7,15 +7,37 @@ describe_samples do
     group: ENV['CS_AGGREGATION_GROUP'],
   }.compact
 
-  rack_active = rack_queued = 0
-  `cat /proc/net/unix`.split("\n").each do |line|
-    next unless line =~ %r{/(unicorn|puma).sock$}
+  if ENV["PUMA_STATS_FILE_PATH"].to_s != ""
+    stats_file = File.expand_path(ENV["PUMA_STATS_FILE_PATH"], "/var/www/railsapp")
+    begin
+      stats = File.read(stats_file)
 
-    _, _, _, _, _, _, inode, = line.split(' ')
-    if inode == "0"
-      rack_queued += 1
-    else
-      rack_active += 1
+      data = stats.scan(/"rack_active"\s*:\s*(\d+)/).first
+      rack_active = data.first.to_i if data
+
+      data = stats.scan(/"rack_queued"\s*:\s*(\d+)/).first
+      rack_queued = data.first.to_i if data
+    rescue # rubocop:disable Style/RescueStandardError
+      # maybe report - later
+    end
+  end
+
+  # Fallback solution - if the stats file is not configured or not readable or
+  # some other problem happened parsing it.
+  if rack_queued.nil?
+    rack_active = rack_queued = 0
+
+    File.readlines("/proc/net/unix").each do |line|
+      next unless line.end_with?("/puma.sock")
+
+      inode = line.split(" ")[6]
+      next unless inode
+
+      if inode == "0"
+        rack_queued += 1
+      else
+        rack_active += 1
+      end
     end
   end
 


### PR DESCRIPTION
Ensures that the socket data reported as metric is consistent with the data used by the application to block requests - i.e. "single source of truth".

Keeps the fallback implementation for exceptional conditions:
- the stack was not configured with a stats file
- a relative stats file path is not resolved correctly with the
  hardcoded (assumed) railsapp directory
- the stats file is not accessible from the plugin's container
- the stats file contents could not be parsed successfully
- puma did not yet write the file, because the plugin is run "too early
  for the recent puma startup".

Given `rack_queued` is the important metric, this one is used to decide whether the fallback needs to be run.