### PR TITLE
[puma stats] See directly what's written to disk

### DIFF
--- a/puma.rb
+++ b/puma.rb
@@ -13,6 +13,8 @@ describe_samples do
   next if Time.now - File.mtime(stats_file) > 5
 
   stats = File.read(stats_file)
+  puts("Puma stats content: #{stats}")
+
   unless stats.count("{") == stats.count("}")
     stats = File.read(stats_file)
 


### PR DESCRIPTION
Metrics aggregate aggressively. But the request blocker faces a single data point, and needs to make a conscious decision base on non-aggregated data.